### PR TITLE
feat: update rank_spider(Python) to adapt RankLand v0.3.9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ cookie.txt
 out.srk.json
 rank_spider/domjudge_image_detection/detection/
 rank_spider/domjudge_image_detection/result/
+rank_spider/icpc/*
+rank_spider/ccpc/*
+rank_spider/province/*

--- a/rank_spider/rank3.py
+++ b/rank_spider/rank3.py
@@ -215,9 +215,24 @@ class Rank:
         for p in problems:
             self.problems.append(p.problem)
         
-        self.series = []
-        for s in series:
-            self.series.append(s.series)
+        # 自动隐藏主 # 列逻辑：
+        # 只有当分组 series 的 id 在 markers 里出现，并且分组 series 有奖牌（segments）时，才隐藏 # 列
+        _series = [s.series if hasattr(s, 'series') else s for s in series]
+        marker_ids = set()
+        if markers is not None:
+            for m in markers:
+                marker_ids.add(m.marker['id'])
+        # 只统计 title 在 markers 里的分组（不含 R# S#），且数量大于1才删 #
+        group_series = [s for s in _series if isinstance(s.get('title', None), str) and s['title'] not in ['#', 'R#', 'S#'] and s['title'].endswith('#')]
+        # 统计 title 去掉 # 后是否在 marker label 里
+        marker_labels = set()
+        if markers is not None:
+            for m in markers:
+                marker_labels.add(m.marker['label'])
+        valid_group_series = [s for s in group_series if s['title'][:-1] in marker_labels]
+        if len(valid_group_series) > 1:
+            _series = [s for s in _series if s.get('title', None) != '#']
+        self.series = _series
         
         self.rows = rows
 
@@ -251,7 +266,7 @@ class Rank:
     def result(self) -> Dict[str, Any]:
         rank = {
             'type': 'general',
-            'version': '0.3.7',
+            'version': '0.3.9',
             'contest': self.contest,
             'problems': self.problems,
             'series': self.series,

--- a/rank_spider/xcpcio.py
+++ b/rank_spider/xcpcio.py
@@ -149,16 +149,19 @@ def main():
     icpc = {}
     for k, v in url['icpc'].items():
         for vk, vv in v.items():
-            icpc[k+vk] = vv['board_link']
+            if 'board_link' in vv:
+                icpc[k+vk] = vv['board_link']
 
     ccpc = {}
     for k, v in url['ccpc'].items():
         for vk, vv in v.items():
-            ccpc[k+vk] = vv['board_link']
+            if 'board_link' in vv:
+                ccpc[k+vv] = vv['board_link']
     province = {}
     for k, v in url['provincial-contest'].items():
         for vk, vv in v.items():
-            province[k+vk] = vv['board_link']
+            if 'board_link' in vv:
+                province[k+vk] = vv['board_link']
         
     icpc.pop('2018world-finals')
     icpc.pop('2019world-finals')


### PR DESCRIPTION
- 自动创建办单数据目录
- 对于多 series 且有奖牌数据的隐藏 # 列
- marker 颜色调整
- 优化 row.user.markers 分组逻辑